### PR TITLE
Hotfix for get()

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "the-traveler",
-    "version": "0.2.0",
+    "version": "0.2.1",
     "description": "A Node.js API wrapper for the Destiny 2 API",
     "keywords": [
         "destiny2",

--- a/src/HttpService.ts
+++ b/src/HttpService.ts
@@ -21,6 +21,7 @@ export default class HTTPService {
      */
     public get(options: rp.OptionsWithUri): Promise<object> {
         options.method = 'GET';
+        options.json = true;
         if (this.debug) {
             console.log('\x1b[33m%s\x1b[0m', 'Debug url:' + options.uri);
         }


### PR DESCRIPTION
HTTPService.get() was not returning JSON in some cases. This is now fixed.